### PR TITLE
질문 / 답변 / 검색페이지 3차 수정

### DIFF
--- a/app/answer/answerMain/page.tsx
+++ b/app/answer/answerMain/page.tsx
@@ -30,25 +30,38 @@ export default function AnswerMainPage() {
 
   const getData = async (page: number) => {
     setLoading(true);
-    const response = await getAnswerListByCategory({
-      categoryId: selectedField + 1,
-      page,
-      size: PAGE_SIZE,
-      sort,
-    });
+    try {
+      const response = await getAnswerListByCategory({
+        categoryId: selectedField + 1,
+        page,
+        size: PAGE_SIZE,
+        sort,
+      });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const mappedQuestions = response.content.map((question: any) => ({
-      question_id: question.question_id,
-      title: question.title,
-      content: question.content,
-      answerCount: question.answerCount,
-      createdDate: question.createdDate,
-    }));
+      if (!response || !response.content) {
+        console.error('Invalid API response:', response);
+        setQuestions([]);
+        setLoading(false);
+        return;
+      }
 
-    setQuestions(mappedQuestions);
-    setTotalPages(response.totalPages);
-    setLoading(false);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mappedQuestions = response.content.map((question: any) => ({
+        question_id: question.question_id,
+        title: question.title,
+        content: question.content,
+        unreadAnswerCnt: 0,
+        answerCnt: question.answerCount ?? 0,
+        createdDate: question.createdDate,
+      }));
+
+      setQuestions(mappedQuestions);
+      setTotalPages(response.totalPages);
+    } catch (error) {
+      console.error('Failed to fetch data:', error);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -83,7 +96,8 @@ export default function AnswerMainPage() {
               question_id={question.question_id}
               title={question.title}
               content={question.content}
-              answerCount={question.answerCount}
+              unreadAnswerCnt={0}
+              answerCnt={question.answerCnt}
               createdDate={question.createdDate}
             />
           ))}

--- a/app/answer/answerMain/page.tsx
+++ b/app/answer/answerMain/page.tsx
@@ -18,10 +18,11 @@ export default function AnswerMainPage() {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [totalPages, setTotalPages] = useState<number>(1);
   const [loading, setLoading] = useState(false);
+  const [sort, setSort] = useState<string>('latest');
 
   useEffect(() => {
     getData(1);
-  }, [selectedField]);
+  }, [selectedField, sort]);
 
   useEffect(() => {
     if (currentPage !== 0) getData(currentPage);
@@ -33,6 +34,7 @@ export default function AnswerMainPage() {
       categoryId: selectedField + 1,
       page,
       size: PAGE_SIZE,
+      sort,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -70,7 +72,7 @@ export default function AnswerMainPage() {
         <p className="text-black font-[600] py-8">
           답변 가능한 질문 {questions?.length?.toLocaleString()}개가 있어요
         </p>
-        <SortSelector />
+        <SortSelector onSortChange={setSort} />
       </div>
 
       <div className="w-[70%] flex flex-col">

--- a/app/answer/answerMain/page.tsx
+++ b/app/answer/answerMain/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 'use client';
 
 import PreviewCard from '@/components/PreviewCard';

--- a/app/apis/answerApi.ts
+++ b/app/apis/answerApi.ts
@@ -105,14 +105,16 @@ export const getAnswerListByCategory = async ({
   categoryId,
   size,
   page,
+  sort = 'latest',
 }: {
   categoryId: number;
   size: number;
   page: number;
+  sort?: string;
 }) => {
   const data = await clientFetchWithAuth({
     method: 'GET',
-    url: `/answers?category_id=${categoryId}&page=${page - 1}&size=${size}&sort=latest`,
+    url: `/answers?category_id=${categoryId}&page=${page - 1}&size=${size}&sort=${sort}`,
   });
 
   return data;
@@ -122,14 +124,16 @@ export const getAnswerSearch = async ({
   search,
   size,
   page,
+  sort = 'latest',
 }: {
   search: string;
   size: number;
   page?: number;
+  sort?: string;
 }) => {
   const data = await clientFetchWithAuth({
     method: 'GET',
-    url: `/answers/search?value=${search}&page=${page !== undefined ? page - 1 : page}&size=${size}`,
+    url: `/answers/search?value=${search}&page=${page !== undefined ? page - 1 : page}&size=${size}&sort=${sort}`,
   });
 
   return data;

--- a/app/apis/myPageApi.ts
+++ b/app/apis/myPageApi.ts
@@ -4,14 +4,16 @@ export const getMyQuestionList = async ({
   categoryId,
   page,
   pageSize,
+  sort = 'latest',
 }: {
   categoryId: number;
   page?: number;
   pageSize?: number;
+  sort?: string;
 }) => {
   const data = await clientFetchWithAuth({
     method: 'GET',
-    url: `/users/mypage?category_id=${categoryId}&page=${page !== undefined ? page - 1 : page}&size=${pageSize}&sort=latest`,
+    url: `/users/mypage?category_id=${categoryId}&page=${page !== undefined ? page - 1 : page}&size=${pageSize}&sort=${sort}`,
   });
 
   return data;

--- a/app/apis/questionApi.ts
+++ b/app/apis/questionApi.ts
@@ -10,7 +10,7 @@ export const setQuestion = async ({
   categoryId: number;
   content: string;
   title: string;
-  images?: File[];
+  images?: (string | File)[];
 }) => {
   const formData = new FormData();
   const requestDto = JSON.stringify({
@@ -44,25 +44,55 @@ export const editQuestion = async ({
   title,
   content,
   categoryId,
+  images,
 }: {
   questionId: number;
   title: string;
   content: string;
-  categoryId: number; //카테고리 ID - 1:전체 2:자연계 3:인문계 4:예체능 5:실무
+  categoryId: number;
+  images?: (string | File)[];
 }) => {
+  console.log('📌 전달된 데이터:', {title, content, categoryId, images});
+
+  const formData = new FormData();
+
+  const requestDto = JSON.stringify({
+    title,
+    content,
+    category_id: categoryId,
+  });
+
+  formData.append(
+    'requestDto',
+    new Blob([requestDto], {type: 'application/json'}),
+  );
+
+  if (images && images.length > 0) {
+    images.forEach(image => {
+      if (image instanceof File) {
+        console.log(`📌 이미지 추가:`, image);
+        formData.append('images', image);
+      }
+    });
+  }
+
+  console.log('📌 최종 FormData:', formData);
+
   const data = await fetchWithAuth({
     method: 'PUT',
     url: `/questions/${questionId}`,
-    body: {
-      title: title,
-      content: content,
-      category_id: categoryId,
-    },
+    body: formData,
   });
-  if (data?.success) toast.success('질문을 수정했습니다');
-  else toast.error(data.message);
 
-  return data?.success;
+  console.log('📌 editQuestion 응답:', data);
+
+  if (data?.success) {
+    toast.success('질문을 수정했습니다');
+    return data;
+  } else {
+    toast.error(data.message);
+    return null;
+  }
 };
 
 export const deleteQuestion = async (questionId: string | number) => {

--- a/app/apis/questionApi.ts
+++ b/app/apis/questionApi.ts
@@ -56,6 +56,7 @@ export const editQuestion = async ({
 
   const formData = new FormData();
 
+  // JSON 데이터를 Blob으로 변환하여 `requestDto` 추가
   const requestDto = JSON.stringify({
     title,
     content,
@@ -67,21 +68,28 @@ export const editQuestion = async ({
     new Blob([requestDto], {type: 'application/json'}),
   );
 
+  // 이미지 처리 (파일만 추가)
   if (images && images.length > 0) {
     images.forEach(image => {
       if (image instanceof File) {
-        console.log(`📌 이미지 추가:`, image);
+        console.log(`📌 새 이미지 추가:`, image.name);
         formData.append('images', image);
       }
     });
+  } else {
+    console.log('📌 requestDto만 전송');
   }
 
-  console.log('📌 최종 FormData:', formData);
+  console.log('📌 최종 FormData:');
+  for (const [key, value] of formData.entries()) {
+    console.log(`${key}:`, value);
+  }
 
   const data = await fetchWithAuth({
     method: 'PUT',
     url: `/questions/${questionId}`,
     body: formData,
+    isFormData: true,
   });
 
   console.log('📌 editQuestion 응답:', data);

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -69,10 +69,11 @@ export default function MyPage() {
   const [info, setInfo] = useState<UserInfo | undefined>(undefined);
   const [totalPages, setTotalPages] = useState<number>(1);
   const [loading, setLoading] = useState<boolean>(true);
+  const [sort, setSort] = useState<string>('latest');
 
   useEffect(() => {
     setData(selectedField, currentPage);
-  }, [selectedField, currentPage]);
+  }, [selectedField, currentPage, sort]);
 
   const setData = async (selectedField: number, page: number) => {
     setLoading(true);
@@ -81,6 +82,7 @@ export default function MyPage() {
         categoryId: selectedField + 1,
         page,
         pageSize: PAGE_SIZE,
+        sort,
       });
 
       const {questions, ...nowInfo} = response;
@@ -120,7 +122,7 @@ export default function MyPage() {
             ? `${CATEGORIES[selectedField]} 분야의 등록된 질문은 ${questionList.length}개가 있어요`
             : `지금까지 총 ${questionList.length}개의 질문을 작성했어요`}
         </p>
-        <SortSelector />
+        <SortSelector onSortChange={setSort} />
       </div>
 
       {loading ? (

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -88,7 +88,7 @@ export default function MyPage() {
           question_id: question.questionId,
           title: question.title,
           content: question.content,
-          answerCount: question.answerCnt,
+          answerCount: question.unreadAnswerCnt,
           createdDate: question.createdDate,
         }),
       );

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 'use client';
 
@@ -136,6 +137,7 @@ export default function MyPage() {
               content={question.content}
               answerCount={question.answerCount}
               createdDate={question.createdDate}
+              isMyPage={true}
             />
           ))}
         </div>

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -91,7 +91,8 @@ export default function MyPage() {
           question_id: question.questionId,
           title: question.title,
           content: question.content,
-          answerCount: question.unreadAnswerCnt,
+          unreadAnswerCnt: question.unreadAnswerCnt,
+          answerCnt: question.answerCnt,
           createdDate: question.createdDate,
         }),
       );
@@ -137,7 +138,8 @@ export default function MyPage() {
               question_id={question.question_id}
               title={question.title}
               content={question.content}
-              answerCount={question.answerCount}
+              unreadAnswerCnt={question.unreadAnswerCnt}
+              answerCnt={question.answerCnt}
               createdDate={question.createdDate}
               isMyPage={true}
             />

--- a/app/question/questionCreate/page.tsx
+++ b/app/question/questionCreate/page.tsx
@@ -15,7 +15,7 @@ export default function QuestionCreatePage() {
   const [selectedStep, setSelectedStep] = useState<number | null>(null);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [images, setImages] = useState<File[]>([]);
+  const [images, setImages] = useState<(string | File)[]>([]);
   const [questionSubmit, setQuestionSubmit] = useState(false);
 
   const searchParams = useSearchParams();
@@ -27,12 +27,16 @@ export default function QuestionCreatePage() {
 
   const setEdit = async (edit: number) => {
     const response = await getAnswerDetail(edit);
-    console.log(response);
+    console.log('📌 API 응답:', response);
 
     setTitle(response.title);
-    setImages(response.images);
     setContent(response.content);
     setSelectedField(response.categoryId - 1);
+
+    const imageList = Array.isArray(response.imageUrls)
+      ? response.imageUrls
+      : [];
+    setImages(imageList);
   };
 
   const handleSubmit = async () => {
@@ -54,6 +58,7 @@ export default function QuestionCreatePage() {
             categoryId: selectedField,
             title,
             content,
+            images,
           })
         : await setQuestion({
             categoryId: selectedField,

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -52,7 +52,7 @@ export default function Page() {
 
       <div className="w-[70%] flex justify-between">
         <p className="text-black font-[600] py-8">
-          질문 {questions?.length}개가 있어요
+          {query} 관련 질문 {questions?.length}개가 있어요
         </p>
         <SortSelector />
       </div>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 'use client';
 
 import SearchBar from '@/components/SearchBar';
@@ -14,37 +15,49 @@ export default function Page() {
   const searchParams = useSearchParams();
   const query = searchParams.get('q') || '';
 
-  const [questions, setQuestions] = useState<PreviewCardProps[] | []>([]);
+  const [questions, setQuestions] = useState<PreviewCardProps[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const [totalPages, setTotalPages] = useState(1);
   const [sort, setSort] = useState<string>('latest');
 
   useEffect(() => {
-    getData(query);
+    getData();
   }, [query, currentPage, sort]);
 
-  const getData = async (query: string) => {
+  const getData = async () => {
     setLoading(true);
-    const data = await getAnswerSearch({
-      search: query,
-      page: currentPage,
-      size: PAGE_SIZE,
-      sort,
-    });
+    try {
+      const data = await getAnswerSearch({
+        search: query,
+        page: currentPage,
+        size: PAGE_SIZE,
+        sort,
+      });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const mappedQuestions = data.content.map((question: any) => ({
-      question_id: question.questionId,
-      title: question.title,
-      content: question.content,
-      answerCount: question.answerCnt || 0,
-      createdDate: question.createdDate,
-    }));
+      if (!data || !data.content) {
+        console.error('Invalid API response:', data);
+        setQuestions([]);
+        setLoading(false);
+        return;
+      }
 
-    setQuestions(mappedQuestions);
-    setTotalPages(data.totalPages);
-    setLoading(false);
+      const mappedQuestions = data.content.map((question: any) => ({
+        question_id: question.questionId,
+        title: question.title,
+        content: question.content,
+        unreadAnswerCnt: 0,
+        answerCnt: question.answerCnt ?? 0,
+        createdDate: question.createdDate,
+      }));
+
+      setQuestions(mappedQuestions);
+      setTotalPages(data.totalPages);
+    } catch (error) {
+      console.error('Failed to fetch data:', error);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -53,7 +66,7 @@ export default function Page() {
 
       <div className="w-[70%] flex justify-between">
         <p className="text-black font-[600] py-8">
-          {query} 관련 질문 {questions?.length}개가 있어요
+          {query} 관련 질문 {questions?.length.toLocaleString()}개가 있어요
         </p>
         <SortSelector onSortChange={setSort} />
       </div>
@@ -66,7 +79,8 @@ export default function Page() {
               question_id={question.question_id}
               title={question.title}
               content={question.content}
-              answerCount={question.answerCount}
+              unreadAnswerCnt={question.unreadAnswerCnt}
+              answerCnt={question.answerCnt}
               createdDate={question.createdDate}
             />
           ))}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -9,7 +9,6 @@ import {useSearchParams} from 'next/navigation';
 import {getAnswerSearch} from '../apis/answerApi';
 import Pagination from '@/components/Pagination';
 import {PreviewCardProps} from '@/type';
-import {convertCreatedDate} from '@/utils/dateUtils';
 
 export default function Page() {
   const searchParams = useSearchParams();
@@ -37,8 +36,8 @@ export default function Page() {
       question_id: question.questionId,
       title: question.title,
       content: question.content,
-      answerCount: question.answerCnt,
-      createdDate: convertCreatedDate(question.createdDate),
+      answerCount: question.answerCnt || 0,
+      createdDate: question.createdDate,
     }));
 
     setQuestions(mappedQuestions);

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -18,10 +18,11 @@ export default function Page() {
   const [currentPage, setCurrentPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const [totalPages, setTotalPages] = useState(1);
+  const [sort, setSort] = useState<string>('latest');
 
   useEffect(() => {
     getData(query);
-  }, [query, currentPage]);
+  }, [query, currentPage, sort]);
 
   const getData = async (query: string) => {
     setLoading(true);
@@ -29,6 +30,7 @@ export default function Page() {
       search: query,
       page: currentPage,
       size: PAGE_SIZE,
+      sort,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -53,7 +55,7 @@ export default function Page() {
         <p className="text-black font-[600] py-8">
           {query} 관련 질문 {questions?.length}개가 있어요
         </p>
-        <SortSelector />
+        <SortSelector onSortChange={setSort} />
       </div>
 
       <div className="w-[70%] flex flex-col">

--- a/components/Answer.tsx
+++ b/components/Answer.tsx
@@ -7,13 +7,11 @@ import {deleteThumbsUP, setThumbsUP} from '@/app/apis/thumbsUPApi';
 import {answerDetailType} from '@/type';
 import {convertCreatedDate, getKSTTimeAgo} from '@/utils/dateUtils';
 import {IoIosClose} from 'react-icons/io';
-
 const Answer = forwardRef(function Answer(
   {
     answer,
     isMyQuestion,
     onSelect,
-    chooseAnswerId,
     isCentered,
   }: {
     answer?: answerDetailType;
@@ -27,6 +25,7 @@ const Answer = forwardRef(function Answer(
   const [thumbsUp, setThumbsUp] = useState(false);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [timeAgo, setTimeAgo] = useState<string>('등록일 없음');
+  const [isChosen, setIsChosen] = useState(answer?.is_chosen || false);
 
   useEffect(() => {
     if (!answer?.createdDate) {
@@ -54,8 +53,6 @@ const Answer = forwardRef(function Answer(
     );
   }
 
-  const iChosed = chooseAnswerId === answer?.answerId;
-
   const handleThumbsUP = async () => {
     setThumbsUp(prev => !prev);
     if (thumbsUp) await deleteThumbsUP(answer?.answerId);
@@ -70,6 +67,21 @@ const Answer = forwardRef(function Answer(
     setSelectedImage(null);
   };
 
+  const handleChooseClick = async () => {
+    if (!answer) return;
+
+    try {
+      if (isChosen === answer.is_chosen) {
+        console.warn('이미 동일한 상태로 요청을 보낼 수 없습니다.');
+        return;
+      }
+
+      await onSelect(answer.answerId);
+      setIsChosen(prev => !prev);
+    } catch (error) {
+      console.error('채택 처리 실패:', error);
+    }
+  };
   return (
     <div
       ref={ref}
@@ -80,7 +92,7 @@ const Answer = forwardRef(function Answer(
     >
       <div className="flex justify-between items-center">
         <div className="flex gap-8 w-[87%]">
-          {iChosed ? (
+          {isChosen ? (
             <div className="absolute top-0 left-6 transition-transform duration-300 ease-in-out transform scale-100">
               <img
                 src="/images/question/adopt.png"
@@ -141,14 +153,16 @@ const Answer = forwardRef(function Answer(
         </button>
 
         {isMyQuestion ? (
-          !iChosed && (
-            <button
-              className="bg-[#7BA1FF] text-white text-sm font-semibold px-4 py-2 rounded-xl transition hover:bg-[#5a82e6]"
-              onClick={() => onSelect(answer?.answerId)}
-            >
-              채택하기
-            </button>
-          )
+          <button
+            className={`text-white text-sm font-semibold px-4 py-2 rounded-xl transition ${
+              isChosen
+                ? 'bg-red-500 hover:bg-red-600'
+                : 'bg-[#7BA1FF] hover:bg-[#5a82e6]'
+            }`}
+            onClick={handleChooseClick}
+          >
+            {isChosen ? '채택 취소' : '채택하기'}
+          </button>
         ) : (
           <p className="text-xs md:text-sm text-[#606060]">{timeAgo}</p>
         )}

--- a/components/Answer.tsx
+++ b/components/Answer.tsx
@@ -71,17 +71,13 @@ const Answer = forwardRef(function Answer(
     if (!answer) return;
 
     try {
-      if (isChosen === answer.is_chosen) {
-        console.warn('이미 동일한 상태로 요청을 보낼 수 없습니다.');
-        return;
-      }
-
       await onSelect(answer.answerId);
       setIsChosen(prev => !prev);
     } catch (error) {
       console.error('채택 처리 실패:', error);
     }
   };
+
   return (
     <div
       ref={ref}

--- a/components/PreviewCard.tsx
+++ b/components/PreviewCard.tsx
@@ -8,7 +8,8 @@ import {getKSTTimeAgo, convertCreatedDate} from '@/utils/dateUtils';
 export default function PreviewCard({
   title,
   content,
-  answerCount,
+  unreadAnswerCnt,
+  answerCnt,
   createdDate,
   question_id,
   isMyPage = false,
@@ -37,7 +38,7 @@ export default function PreviewCard({
 
       <div className="flex justify-between items-center">
         <h2 className="text-md font-[600] text-black">{title}</h2>
-        {isMyPage && answerCount > 0 && (
+        {isMyPage && unreadAnswerCnt > 0 && (
           <div
             className="px-5 py-1 rounded-[44px] text-xs font-[300] text-white"
             style={{
@@ -45,14 +46,14 @@ export default function PreviewCard({
                 'linear-gradient(280deg, #A7C0FF 2.25%, #3765D6 100%)',
             }}
           >
-            +{answerCount}개의 미확인 답변이 있어요
+            +{unreadAnswerCnt}개의 미확인 답변이 있어요
           </div>
         )}
       </div>
 
       <p className="text-[13px] text-[#606060] mt-5 line-clamp-2">{content}</p>
       <div className="mt-4 text-xs text-[#606060] font-[0] flex justify-end space-x-2">
-        <p>답변 {answerCount}개 ·</p>
+        <p>답변 {answerCnt}개 ·</p>
         <p>{timeAgo}</p>
       </div>
     </div>

--- a/components/PreviewCard.tsx
+++ b/components/PreviewCard.tsx
@@ -11,6 +11,7 @@ export default function PreviewCard({
   answerCount,
   createdDate,
   question_id,
+  isMyPage = false,
 }: PreviewCardProps) {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
@@ -36,7 +37,7 @@ export default function PreviewCard({
 
       <div className="flex justify-between items-center">
         <h2 className="text-md font-[600] text-black">{title}</h2>
-        {answerCount > 0 && (
+        {isMyPage && answerCount > 0 && (
           <div
             className="px-5 py-1 rounded-[44px] text-xs font-[300] text-white"
             style={{

--- a/components/SortSelector.tsx
+++ b/components/SortSelector.tsx
@@ -2,13 +2,17 @@ import {SORT_OPTIONS} from '@/constants/sortOptions';
 import Image from 'next/image';
 import {useState} from 'react';
 
-export default function SortSelector() {
+export default function SortSelector({
+  onSortChange,
+}: {
+  onSortChange: (sort: string) => void;
+}) {
   const [sort, setSort] = useState(SORT_OPTIONS[0]);
 
   const toggleSort = () => {
-    setSort(prevSort =>
-      prevSort.value === 'latest' ? SORT_OPTIONS[1] : SORT_OPTIONS[0],
-    );
+    const newSort = sort.value === 'latest' ? SORT_OPTIONS[1] : SORT_OPTIONS[0];
+    setSort(newSort);
+    onSortChange(newSort.value);
   };
 
   return (
@@ -17,7 +21,6 @@ export default function SortSelector() {
       onClick={toggleSort}
     >
       <button className="text-sm font-medium text-black">{sort.label}</button>
-
       <Image src="/svg/sort.svg" alt="Sort Icon" width={20} height={20} />
     </div>
   );

--- a/components/ViewAnswer.tsx
+++ b/components/ViewAnswer.tsx
@@ -14,7 +14,7 @@ export default function ViewAnswer({
   questionId: number;
 }) {
   const [chooseAnswerId, setChooseAnswerId] = useState<number | null>(
-    answers?.find(answer => answer.isChosen)?.answerId ?? null,
+    answers?.find(answer => answer.is_chosen)?.answerId ?? null,
   );
 
   const [centeredAnswerIds, setCenteredAnswerIds] = useState<number[]>([]);

--- a/components/ViewAnswer.tsx
+++ b/components/ViewAnswer.tsx
@@ -59,26 +59,32 @@ export default function ViewAnswer({
   const handleSelectAnswer = async (answerId: number) => {
     if (!questionId) return;
 
-    //1. 현재 채택된 답변이 있다면 해당 답변은 채택 취소
-    if (chooseAnswerId) {
-      await setAnswerChoice({
-        answerId: chooseAnswerId,
-        questionId,
-        isChosen: false,
-      });
-    }
+    const isCancelling = chooseAnswerId === answerId;
+    setChooseAnswerId(isCancelling ? null : answerId);
 
-    //2. 선택된 답변이 채택했었던 답변과 다르다면 채택
-    if (chooseAnswerId !== answerId) {
-      await setAnswerChoice({
-        answerId,
-        questionId,
-        isChosen: true,
-      });
-    }
+    try {
+      // 기존에 선택된 답변이 있으면 취소
+      if (chooseAnswerId) {
+        await setAnswerChoice({
+          answerId: chooseAnswerId,
+          questionId,
+          isChosen: false,
+        });
+      }
 
-    //3.클라이언트측 채택된 답변 수정(낙관적 업데이트)
-    setChooseAnswerId(answerId);
+      // 새로운 답변을 선택 (취소하는 경우 건너뛰기)
+      if (!isCancelling) {
+        await setAnswerChoice({
+          answerId,
+          questionId,
+          isChosen: true,
+        });
+      }
+    } catch (error) {
+      console.error('답변 채택 처리 실패:', error);
+      // 오류 발생 시 원래 상태로 롤백
+      setChooseAnswerId(chooseAnswerId);
+    }
   };
 
   return (

--- a/components/WriteAnswer.tsx
+++ b/components/WriteAnswer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 'use client';
 
 import {FiUpload, FiX} from 'react-icons/fi';

--- a/components/WriteQuestion.tsx
+++ b/components/WriteQuestion.tsx
@@ -2,15 +2,15 @@
 
 import {FiUpload, FiX} from 'react-icons/fi';
 import Image from 'next/image';
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 
 interface WriteQuestionProps {
   title: string;
   setTitle: (title: string) => void;
   content: string;
   setContent: (content: string) => void;
-  images: File[];
-  setImages: (images: File[]) => void;
+  images: (string | File)[];
+  setImages: (images: (string | File)[]) => void;
 }
 
 export default function WriteQuestion({
@@ -22,6 +22,14 @@ export default function WriteQuestion({
   setImages,
 }: WriteQuestionProps) {
   const [previewImages, setPreviewImages] = useState<string[]>([]);
+
+  // 🔹 기존 `imageUrls`(문자열 URL)도 preview에 추가
+  useEffect(() => {
+    const previews = images.map(image =>
+      typeof image === 'string' ? image : URL.createObjectURL(image),
+    );
+    setPreviewImages(previews);
+  }, [images]);
 
   // 이미지 업로드 핸들러
   const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -37,9 +45,9 @@ export default function WriteQuestion({
   // 이미지 삭제 핸들러
   const handleRemoveImage = (index: number) => {
     const updatedImages = images.filter((_, i) => i !== index);
-    const updatedPreviews = previewImages.filter((_, i) => i !== index);
-
     setImages(updatedImages);
+
+    const updatedPreviews = previewImages.filter((_, i) => i !== index);
     setPreviewImages(updatedPreviews);
   };
 
@@ -47,7 +55,7 @@ export default function WriteQuestion({
     <div className="w-full flex flex-col">
       <div className="w-full flex flex-col items-center overflow-hidden rounded-[1.6vw] bg-[url('/images/question/write_question_bg.png')] bg-cover bg-center">
         <div className="flex justify-between items-center w-full pt-[1.3vw] px-[1.1vw]">
-          <label className="cursor-pointer font-semibold ">
+          <label className="cursor-pointer font-semibold">
             <div className="w-[130px] h-[40px] bg-white text-[#4F7DEE] flex items-center justify-center gap-2 rounded-xl">
               <FiUpload className="text-md" />
               <span className="font-[600] text-sm">이미지 삽입</span>

--- a/type.ts
+++ b/type.ts
@@ -23,7 +23,7 @@ export type answerDetailType = {
   content: string;
   createdDate: string | number[];
   like_count: number;
-  isChosen: boolean;
+  is_chosen: boolean;
   imageUrls?: string[];
   universityName: string;
 };

--- a/type.ts
+++ b/type.ts
@@ -80,7 +80,8 @@ export type PreviewCardProps = {
   id?: number;
   title: string;
   content: string;
-  answerCount: number;
+  unreadAnswerCnt: number;
+  answerCnt: number;
   createdDate: string;
   question_id: number;
   isMyPage?: boolean;

--- a/type.ts
+++ b/type.ts
@@ -83,6 +83,7 @@ export type PreviewCardProps = {
   answerCount: number;
   createdDate: string;
   question_id: number;
+  isMyPage?: boolean;
 };
 
 export type universityType = {


### PR DESCRIPTION
### 🚀 연관된 이슈

> #50 

### 📝 작업 내용

- 채택하기 api 재연결
- 마이페이지에서만 미확인 답변 개수 컴포넌트 렌더링
- 검색 페이지 css 수정 및 답변, 날짜 로직 수정
- 게시글 최신순 / 인기순 정렬 로직 추가
- 게시글 수정 페이지에서 이미지 렌더링 안 되는 문제 수정, json → formData로 수정된 api 형식에 맞춰서 로직 수정

### 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
